### PR TITLE
Revert: add AGENTS.md to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -292,4 +292,3 @@ k8s/secret.yaml
 
 # Database
 *.db
-AGENTS.md


### PR DESCRIPTION
## Summary

We will add `AGENTS.md` in future support.

Reverts SingularityLab-SWUFE/fastapi-template-agent#29
