### PR TITLE
fix(middleware): unnecessary rebuild iterator & recalculate headers

### DIFF
--- a/src/responses/middleware.py
+++ b/src/responses/middleware.py
@@ -5,7 +5,6 @@ from typing import Any
 
 from fastapi import Request
 from fastapi.responses import JSONResponse, Response as FastAPIResponse
-from starlette.concurrency import iterate_in_threadpool
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.types import ASGIApp
 
@@ -31,9 +30,6 @@ class ResponseWrapperMiddleware(BaseHTTPMiddleware):
         body_chunks = [chunk async for chunk in api_response.body_iterator]
         body = b"".join(body_chunks)
 
-        # Rebuild iterator so subsequent middleware / response flow remains valid
-        api_response.body_iterator = iterate_in_threadpool(iter(body_chunks))
-
         if not body:
             payload = None
         else:
@@ -46,22 +42,29 @@ class ResponseWrapperMiddleware(BaseHTTPMiddleware):
             new_payload = payload
             status_code = api_response.status_code
         elif 200 <= api_response.status_code < 400:
-            new_payload = Response.success(code=api_response.status_code, data=payload).model_dump()
+            new_payload = Response.success(
+                code=api_response.status_code, data=payload
+            ).model_dump()
             status_code = 200
         else:
             error_msg = self._extract_error_msg(payload)
             error_code = self._extract_error_code(payload, api_response.status_code)
-            new_payload = Response.error(code=error_code, msg=error_msg, data=payload).model_dump()
+            new_payload = Response.error(
+                code=error_code, msg=error_msg, data=payload
+            ).model_dump()
             status_code = api_response.status_code
 
-        unified = JSONResponse(
+        return JSONResponse(
             content=new_payload,
             status_code=status_code,
             media_type=api_response.media_type,
             background=api_response.background,
-            headers=dict(api_response.headers),
+            headers={
+                k: v
+                for k, v in api_response.headers.items()
+                if k.lower() not in ("content-length", "content-encoding")
+            },
         )
-        return unified
 
     def _should_skip(self, request: Request, response: FastAPIResponse) -> bool:
         content_type = (response.headers.get("content-type") or "").lower()
@@ -69,7 +72,9 @@ class ResponseWrapperMiddleware(BaseHTTPMiddleware):
             return True
 
         path = request.url.path
-        if path in self.DOC_PATHS or any(path.startswith(prefix) for prefix in self.DOC_PATH_PREFIXES):
+        if path in self.DOC_PATHS or any(
+            path.startswith(prefix) for prefix in self.DOC_PATH_PREFIXES
+        ):
             return True
 
         if path in self.SKIP_PATHS:
@@ -97,7 +102,9 @@ class ResponseWrapperMiddleware(BaseHTTPMiddleware):
             return payload
 
         if isinstance(payload, dict):
-            detail = payload.get("detail") or payload.get("msg") or payload.get("message")
+            detail = (
+                payload.get("detail") or payload.get("msg") or payload.get("message")
+            )
             if isinstance(detail, str):
                 return detail
             if detail is not None:


### PR DESCRIPTION
## Related Issue

Closes #37

## Summary of Changes

- Remove `body_iterator`
- filtered Content-Length and Content-Encoding headers

## Breaking Changes

N/A

## Checklist

- [x] Issue discussion completed before opening PR
- [x] Scope is small and focused (single feature/fix)
- [x] All functions have full type annotations
- [x] Async/await used for all I/O operations
- [ ] Tests added for new behaviors (No test needed for this PR)
- [x] `uv run pre-commit run --all-files` passes
- [x] `uv run pytest` passes
