### PR TITLE
feat(auth): implement RBAC-based permission system

### DIFF
--- a/migrations/versions/5b7a7f7f3f6a_add_rbac_tables.py
+++ b/migrations/versions/5b7a7f7f3f6a_add_rbac_tables.py
@@ -1,0 +1,126 @@
+"""add rbac tables
+
+Revision ID: 5b7a7f7f3f6a
+Revises: 25b889226314
+Create Date: 2025-12-15 10:45:00.000000
+
+"""
+
+from datetime import datetime
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+# revision identifiers, used by Alembic.
+revision: str = "5b7a7f7f3f6a"
+down_revision: Union[str, Sequence[str], None] = "25b889226314"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "roles",
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "name", sqlmodel.sql.sqltypes.AutoString(length=100), nullable=False
+        ),
+        sa.Column(
+            "description",
+            sqlmodel.sql.sqltypes.AutoString(length=255),
+            nullable=True,
+        ),
+        sa.Column("is_system", sa.Boolean(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_roles_name"), "roles", ["name"], unique=True)
+
+    op.create_table(
+        "permissions",
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "code", sqlmodel.sql.sqltypes.AutoString(length=150), nullable=False
+        ),
+        sa.Column(
+            "name", sqlmodel.sql.sqltypes.AutoString(length=100), nullable=False
+        ),
+        sa.Column(
+            "description",
+            sqlmodel.sql.sqltypes.AutoString(length=255),
+            nullable=True,
+        ),
+        sa.Column(
+            "module", sqlmodel.sql.sqltypes.AutoString(length=100), nullable=False
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_permissions_code"), "permissions", ["code"], unique=True)
+
+    op.create_table(
+        "user_roles",
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("role_id", sa.Integer(), nullable=False),
+        sa.Column("assigned_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["role_id"], ["roles.id"]),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("user_id", "role_id"),
+    )
+
+    op.create_table(
+        "role_permissions",
+        sa.Column("role_id", sa.Integer(), nullable=False),
+        sa.Column("permission_id", sa.Integer(), nullable=False),
+        sa.Column("assigned_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["permission_id"], ["permissions.id"]),
+        sa.ForeignKeyConstraint(["role_id"], ["roles.id"]),
+        sa.PrimaryKeyConstraint("role_id", "permission_id"),
+    )
+
+    now = datetime.utcnow()
+    op.bulk_insert(
+        sa.table(
+            "roles",
+            sa.Column("created_at", sa.DateTime()),
+            sa.Column("updated_at", sa.DateTime()),
+            sa.Column("id", sa.Integer()),
+            sa.Column("name", sa.String()),
+            sa.Column("description", sa.String()),
+            sa.Column("is_system", sa.Boolean()),
+        ),
+        [
+            {
+                "id": 1,
+                "name": "admin",
+                "description": "System administrator role",
+                "is_system": True,
+                "created_at": now,
+                "updated_at": now,
+            },
+            {
+                "id": 2,
+                "name": "user",
+                "description": "Default user role",
+                "is_system": True,
+                "created_at": now,
+                "updated_at": now,
+            },
+        ],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table("role_permissions")
+    op.drop_table("user_roles")
+    op.drop_index(op.f("ix_permissions_code"), table_name="permissions")
+    op.drop_table("permissions")
+    op.drop_index(op.f("ix_roles_name"), table_name="roles")
+    op.drop_table("roles")

--- a/src/auth/__init__.py
+++ b/src/auth/__init__.py
@@ -12,3 +12,28 @@ fastapi_users = FastAPIUsers[User, int](
 
 current_user = fastapi_users.current_user(active=True)
 current_superuser = fastapi_users.current_user(active=True, superuser=True)
+
+from .permissions import (  # noqa: E402
+    PermissionService,
+    get_permission_service,
+    owner_or_perm,
+    require_active_user,
+    require_permissions,
+    require_roles,
+    require_superuser,
+)
+
+__all__ = [
+    "PermissionService",
+    "auth_backend",
+    "current_superuser",
+    "current_user",
+    "fastapi_users",
+    "get_permission_service",
+    "get_user_manager",
+    "owner_or_perm",
+    "require_active_user",
+    "require_permissions",
+    "require_roles",
+    "require_superuser",
+]

--- a/src/auth/manager.py
+++ b/src/auth/manager.py
@@ -2,9 +2,10 @@ from collections.abc import AsyncGenerator
 
 from fastapi import Depends, Request
 from fastapi_users import BaseUserManager, IntegerIDMixin
+from sqlalchemy import select
 
 from src.core.config import Settings, get_settings
-from src.core.schemas import User
+from src.core.schemas import Role, User, UserRole
 
 from fastapi_users.db import SQLAlchemyUserDatabase
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -35,7 +36,22 @@ class UserManager(IntegerIDMixin, BaseUserManager[User, int]):
     async def on_after_register(
         self, user: User, request: Request | None = None
     ) -> None:
-        pass
+        if not self.settings.auth.rbac_enabled:
+            return
+
+        default_role = self.settings.auth.default_user_role
+        if not default_role:
+            return
+
+        result = await self.user_db.session.execute(
+            select(Role).where(Role.name == default_role)
+        )
+        role = result.scalar_one_or_none()
+        if not role:
+            return
+
+        self.user_db.session.add(UserRole(user_id=user.id, role_id=role.id))
+        await self.user_db.session.commit()
 
     async def on_after_forgot_password(
         self, user: User, token: str, request: Request | None = None

--- a/src/auth/permissions.py
+++ b/src/auth/permissions.py
@@ -1,0 +1,157 @@
+from collections.abc import Callable, Sequence
+from typing import Any, Awaitable
+
+from fastapi import Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.config import Settings, get_settings
+from src.core.schemas import (
+    ErrorCode,
+    Permission,
+    Role,
+    RolePermission,
+    User,
+    UserRole,
+)
+from src.exceptions import BusinessException
+from src.session import get_session
+
+from . import current_superuser, current_user
+
+
+class PermissionService:
+    def __init__(self, session: AsyncSession, settings: Settings):
+        self.session = session
+        self.settings = settings
+
+    async def _is_superuser(self, user_id: int) -> bool:
+        result = await self.session.execute(
+            select(User.is_superuser).where(User.id == user_id)
+        )
+        flag = result.scalar_one_or_none()
+        return bool(flag)
+
+    async def get_user_roles(self, user_id: int) -> list[str]:
+        if not self.settings.auth.rbac_enabled:
+            return []
+
+        result = await self.session.execute(
+            select(Role.name)
+            .join(UserRole, UserRole.role_id == Role.id)
+            .where(UserRole.user_id == user_id)
+        )
+        roles = set(result.scalars().all())
+        if await self._is_superuser(user_id):
+            roles.add("superuser")
+        return list(roles)
+
+    async def get_user_permissions(self, user_id: int) -> list[str]:
+        if not self.settings.auth.rbac_enabled:
+            return ["*"] if await self._is_superuser(user_id) else []
+
+        result = await self.session.execute(
+            select(Permission.code)
+            .join(RolePermission, RolePermission.permission_id == Permission.id)
+            .join(Role, Role.id == RolePermission.role_id)
+            .join(UserRole, UserRole.role_id == Role.id)
+            .where(UserRole.user_id == user_id)
+        )
+        perms = set(result.scalars().all())
+        if await self._is_superuser(user_id):
+            perms.add("*")
+        return list(perms)
+
+    async def check_permissions(
+        self,
+        user_id: int,
+        required_perms: Sequence[str],
+    ) -> bool:
+        if not self.settings.auth.rbac_enabled:
+            return True
+
+        if not required_perms:
+            return True
+
+        perms = await self.get_user_permissions(user_id)
+        perm_set = set(perms)
+        if "*" in perm_set:
+            return True
+        return set(required_perms).issubset(perm_set)
+
+    async def check_roles(
+        self,
+        user_id: int,
+        required_roles: Sequence[str],
+    ) -> bool:
+        if not self.settings.auth.rbac_enabled:
+            return True
+
+        if not required_roles:
+            return True
+
+        roles = set(await self.get_user_roles(user_id))
+        return set(required_roles).issubset(roles)
+
+
+def get_permission_service(
+    session: AsyncSession = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> PermissionService:
+    return PermissionService(session, settings)
+
+
+def _raise_permission_error() -> None:
+    raise BusinessException(ErrorCode.PERM_INSUFFICIENT, "Insufficient permissions")
+
+
+def require_permissions(*perms: str) -> Callable[..., Awaitable[Any]]:
+    async def dependency(
+        user=Depends(current_user),
+        service: PermissionService = Depends(get_permission_service),
+    ):
+        allowed = await service.check_permissions(user.id, perms)
+        if not allowed:
+            _raise_permission_error()
+        return user
+
+    return dependency
+
+
+def require_roles(*roles: str) -> Callable[..., Awaitable[Any]]:
+    async def dependency(
+        user=Depends(current_user),
+        service: PermissionService = Depends(get_permission_service),
+    ):
+        allowed = await service.check_roles(user.id, roles)
+        if not allowed:
+            _raise_permission_error()
+        return user
+
+    return dependency
+
+
+def owner_or_perm(
+    resource_getter: Callable[..., Any],
+    perm: str,
+    owner_field: str = "owner_id",
+) -> Callable[..., Awaitable[Any]]:
+    async def dependency(
+        obj=Depends(resource_getter),
+        user=Depends(current_user),
+        service: PermissionService = Depends(get_permission_service),
+    ):
+        owner_id = getattr(obj, owner_field, None)
+        if owner_id == user.id:
+            return obj
+
+        allowed = await service.check_permissions(user.id, [perm])
+        if not allowed:
+            _raise_permission_error()
+        return obj
+
+    return dependency
+
+
+require_active_user = current_user
+require_superuser = current_superuser

--- a/src/core/config/auth.py
+++ b/src/core/config/auth.py
@@ -8,6 +8,8 @@ class AuthSettings(BaseSettings):
     jwt_algorithm: str = Field(default="HS256")
     jwt_lifetime_seconds: int = Field(default=1800)
     refresh_token_lifetime_seconds: int = Field(default=2592000)
+    rbac_enabled: bool = Field(default=True)
+    default_user_role: str = Field(default="user")
 
     oauth_google_client_id: str | None = None
     oauth_google_client_secret: str | None = None

--- a/src/core/schemas/__init__.py
+++ b/src/core/schemas/__init__.py
@@ -2,10 +2,15 @@ from .mixins import TimestampMixin
 from .error import ErrorCode, error_code_to_http_status
 from .oauth import OAuthAccount
 from .registry import redis_keys
+from .rbac import Permission, Role, RolePermission, UserRole
 from .user import User
 
 __all__ = [
     "ErrorCode",
+    "Permission",
+    "Role",
+    "RolePermission",
+    "UserRole",
     "TimestampMixin",
     "OAuthAccount",
     "User",

--- a/src/core/schemas/rbac.py
+++ b/src/core/schemas/rbac.py
@@ -1,0 +1,62 @@
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from sqlmodel import Field, Relationship, SQLModel
+
+from .mixins import TimestampMixin
+
+if TYPE_CHECKING:
+    from .user import User
+
+
+class UserRole(SQLModel, table=True):
+    __tablename__ = "user_roles"
+
+    user_id: int = Field(foreign_key="users.id", primary_key=True)
+    role_id: int = Field(foreign_key="roles.id", primary_key=True)
+    assigned_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+    )
+
+
+class RolePermission(SQLModel, table=True):
+    __tablename__ = "role_permissions"
+
+    role_id: int = Field(foreign_key="roles.id", primary_key=True)
+    permission_id: int = Field(foreign_key="permissions.id", primary_key=True)
+    assigned_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+    )
+
+
+class Role(SQLModel, TimestampMixin, table=True):
+    __tablename__ = "roles"
+
+    id: int | None = Field(default=None, primary_key=True)
+    name: str = Field(unique=True, index=True, max_length=100)
+    description: str | None = Field(default=None, max_length=255)
+    is_system: bool = Field(default=False)
+
+    permissions: list["Permission"] = Relationship(
+        back_populates="roles",
+        link_model=RolePermission,
+    )
+    users: list["User"] = Relationship(
+        back_populates="roles",
+        link_model=UserRole,
+    )
+
+
+class Permission(SQLModel, TimestampMixin, table=True):
+    __tablename__ = "permissions"
+
+    id: int | None = Field(default=None, primary_key=True)
+    code: str = Field(unique=True, index=True, max_length=150)
+    name: str = Field(max_length=100)
+    description: str | None = Field(default=None, max_length=255)
+    module: str = Field(max_length=100)
+
+    roles: list[Role] = Relationship(
+        back_populates="permissions",
+        link_model=RolePermission,
+    )

--- a/src/core/schemas/user.py
+++ b/src/core/schemas/user.py
@@ -1,6 +1,7 @@
-from sqlmodel import Field, SQLModel
+from sqlmodel import Field, Relationship, SQLModel
 
 from .mixins import TimestampMixin
+from .rbac import Role, UserRole
 
 
 class User(SQLModel, TimestampMixin, table=True):
@@ -13,3 +14,8 @@ class User(SQLModel, TimestampMixin, table=True):
     is_active: bool = Field(default=True)
     is_superuser: bool = Field(default=False)
     is_verified: bool = Field(default=False)
+
+    roles: list["Role"] = Relationship(
+        back_populates="users",
+        link_model=UserRole,
+    )

--- a/tests/auth/test_permissions.py
+++ b/tests/auth/test_permissions.py
@@ -1,0 +1,120 @@
+import pytest
+from fastapi_users.password import PasswordHelper
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.auth.permissions import PermissionService, owner_or_perm, require_permissions
+from src.core.config import get_settings
+from src.core.schemas import Permission, Role, RolePermission, User, UserRole
+from src.exceptions import BusinessException
+
+
+@pytest.mark.asyncio
+async def test_get_user_permissions_with_role(test_db) -> None:
+    settings = get_settings()
+    async with test_db() as session:  # type: AsyncSession
+        role = Role(name="editor", description="Editor role", is_system=False)
+        permission = Permission(
+            code="article:write",
+            name="Article write",
+            module="article",
+            description="Can write articles",
+        )
+        session.add_all([role, permission])
+        await session.flush()
+        session.add(RolePermission(role_id=role.id, permission_id=permission.id))
+
+        password_helper = PasswordHelper()
+        user = User(
+            username="perm_user",
+            email="perm_user@example.com",
+            hashed_password=password_helper.hash("password123"),
+            is_active=True,
+            is_verified=True,
+            is_superuser=False,
+        )
+        session.add(user)
+        await session.flush()
+        session.add(UserRole(user_id=user.id, role_id=role.id))
+        await session.commit()
+
+        service = PermissionService(session, settings)
+        perms = await service.get_user_permissions(user.id)
+
+        assert "article:write" in perms
+
+
+@pytest.mark.asyncio
+async def test_require_permissions_denied_when_missing(test_db) -> None:
+    settings = get_settings()
+    async with test_db() as session:  # type: AsyncSession
+        password_helper = PasswordHelper()
+        user = User(
+            username="no_perm",
+            email="no_perm@example.com",
+            hashed_password=password_helper.hash("password123"),
+            is_active=True,
+            is_verified=True,
+            is_superuser=False,
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+
+        service = PermissionService(session, settings)
+        dependency = require_permissions("demo:write")
+
+        with pytest.raises(BusinessException):
+            await dependency(user=user, service=service)
+
+
+@pytest.mark.asyncio
+async def test_owner_or_perm_allows_owner(test_db) -> None:
+    settings = get_settings()
+    async with test_db() as session:  # type: AsyncSession
+        password_helper = PasswordHelper()
+        user = User(
+            username="owner_user",
+            email="owner_user@example.com",
+            hashed_password=password_helper.hash("password123"),
+            is_active=True,
+            is_verified=True,
+            is_superuser=False,
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+
+        service = PermissionService(session, settings)
+
+        class Resource:
+            def __init__(self, owner_id: int):
+                self.owner_id = owner_id
+
+        resource = Resource(owner_id=user.id)
+
+        dependency = owner_or_perm(lambda: resource, "resource:edit")
+        result = await dependency(obj=resource, user=user, service=service)
+
+        assert result is resource
+
+
+@pytest.mark.asyncio
+async def test_superuser_bypass(test_db) -> None:
+    settings = get_settings()
+    async with test_db() as session:  # type: AsyncSession
+        password_helper = PasswordHelper()
+        user = User(
+            username="super_admin",
+            email="super_admin@example.com",
+            hashed_password=password_helper.hash("password123"),
+            is_active=True,
+            is_verified=True,
+            is_superuser=True,
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+
+        service = PermissionService(session, settings)
+
+        assert await service.check_permissions(user.id, ["any:perm"])

--- a/tests/integration/test_rbac_integration.py
+++ b/tests/integration/test_rbac_integration.py
@@ -1,0 +1,154 @@
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi_users.password import PasswordHelper
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+from src.auth import current_user
+from src.auth.permissions import require_permissions
+from src.core.schemas import Permission, Role, RolePermission, User, UserRole
+from src.handlers import register_exception_handlers
+from src.session import get_session
+
+
+@pytest.fixture
+async def session_maker():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    yield maker
+
+    await engine.dispose()
+
+
+@pytest.fixture
+async def app(session_maker):
+    async def override_get_session():
+        async with session_maker() as session:
+            yield session
+
+    app = FastAPI()
+    app.dependency_overrides[get_session] = override_get_session
+    register_exception_handlers(app)
+
+    @app.get("/articles")
+    async def list_articles(user=Depends(require_permissions("article:read"))):
+        return {"ok": True}
+
+    yield app
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+async def client(app: FastAPI):
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        yield client
+
+
+async def _create_user_with_perm(session: AsyncSession) -> User:
+    helper = PasswordHelper()
+    role = Role(name="editor", description="Editor role", is_system=False)
+    perm = Permission(
+        code="article:read",
+        name="Article read",
+        module="article",
+        description="Read articles",
+    )
+    session.add_all([role, perm])
+    await session.flush()
+    session.add(RolePermission(role_id=role.id, permission_id=perm.id))
+
+    user = User(
+        username="editor_user",
+        email="editor@example.com",
+        hashed_password=helper.hash("password123"),
+        is_active=True,
+        is_verified=True,
+        is_superuser=False,
+    )
+    session.add(user)
+    await session.flush()
+    session.add(UserRole(user_id=user.id, role_id=role.id))
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+async def _create_plain_user(session: AsyncSession) -> User:
+    helper = PasswordHelper()
+    user = User(
+        username="plain_user",
+        email="plain@example.com",
+        hashed_password=helper.hash("password123"),
+        is_active=True,
+        is_verified=True,
+        is_superuser=False,
+    )
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+async def _create_superuser(session: AsyncSession) -> User:
+    helper = PasswordHelper()
+    user = User(
+        username="boss",
+        email="boss@example.com",
+        hashed_password=helper.hash("password123"),
+        is_active=True,
+        is_verified=True,
+        is_superuser=True,
+    )
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+@pytest.mark.asyncio
+async def test_access_allowed_with_permission(app: FastAPI, client: AsyncClient, session_maker):
+    async with session_maker() as session:
+        user = await _create_user_with_perm(session)
+
+    app.dependency_overrides[current_user] = lambda: user
+
+    response = await client.get("/articles")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_access_denied_without_permission(app: FastAPI, client: AsyncClient, session_maker):
+    async with session_maker() as session:
+        user = await _create_plain_user(session)
+
+    app.dependency_overrides[current_user] = lambda: user
+
+    response = await client.get("/articles")
+
+    assert response.status_code == 403
+    assert response.json()["code"] == 30001
+
+
+@pytest.mark.asyncio
+async def test_superuser_bypass_permissions(app: FastAPI, client: AsyncClient, session_maker):
+    async with session_maker() as session:
+        user = await _create_superuser(session)
+
+    app.dependency_overrides[current_user] = lambda: user
+
+    response = await client.get("/articles")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}


### PR DESCRIPTION
## Related Issue

Closes #13 #41

## Summary of Changes

  - 增加 RBAC 模型与配置支持（角色、权限、多对多关联与默认角色开关）
  - 新增权限服务与依赖工厂，支持 require_permissions/require_roles/owner_or_perm 等鉴权注入
  - 补充 Alembic 迁移创建 RBAC 表并预置 admin/user 角色
  - 添加权限单元测试与集成测试，覆盖角色授权、无权拒绝、Owner 放行、超级管理员绕过等场景

## Breaking Changes

N/A

## Checklist

- [ ] Issue discussion completed before opening PR
- [ ] Scope is small and focused (single feature/fix)
- [x] All functions have full type annotations
- [x] Async/await used for all I/O operations
- [x] Tests added for new behaviors
- [x] `uv run pre-commit run --all-files` passes
- [x] `uv run pytest` passes
