### PR TITLE
fix(ci): enable cc write permission

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,9 +20,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Related Issue

Closes #7

## Summary of Changes

This may because yml file is missing write permissions. The error occurs because Claude Code Action cannot create and push branches without contents: write permission. We will give it a shot to see whether this change would work.
