### PR TITLE
feat(agent): commands for calling agents

### DIFF
--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,0 +1,5 @@
+Plan implementation approach for the given task using the planner agent.
+
+Follow the Explore → Plan → Implement paradigm. Read relevant files, identify affected modules, choose the simplest approach that aligns with existing patterns. Ask one critical clarifying question if requirements are unclear.
+
+Task: $ARGUMENTS

--- a/.claude/commands/refactor.md
+++ b/.claude/commands/refactor.md
@@ -1,0 +1,5 @@
+Identify and remove dead code, consolidate duplicates, and perform cleanup refactoring using the refactor-cleaner agent.
+
+Run vulture and grep to detect unused code. Verify each finding against the safety checklist before removal. Keep diffs minimal and scoped to cleanup only.
+
+Scope: $ARGUMENTS

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,5 @@
+Review code changes on the current branch using the code-reviewer agent.
+
+Run `git diff` to see all staged and unstaged changes. If on a feature branch, also run `git diff main...HEAD` to see all branch changes. Begin review immediately following the code-reviewer agent guidelines.
+
+$ARGUMENTS


### PR DESCRIPTION
## Related Issue

Closes #95

## Summary of Changes

- Add three Claude Code slash commands: `/plan`, `/refactor`, `/review`
- Each command invokes its corresponding agent with `$ARGUMENTS` passthrough

## Breaking Changes

N/A

## Checklist

- [x] Issue discussion completed before opening PR
- [x] Scope is small and focused (single feature/fix)
- [ ] All functions have full type annotations
- [ ] Async/await used for all I/O operations
- [ ] Tests added for new behaviors
