### PR TITLE
fix: set default_language_version for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+default_language_version:
+    python: python3.12
+
 repos:
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.5


### PR DESCRIPTION
Set `default_language_version` to `python3.12` in `.pre-commit-config.yaml`. This ensures that hooks like `debug-statements` use a Python version compatible with 3.10+ syntax (like match/case statements) used in the project. Fixes #138